### PR TITLE
Update seed.rs

### DIFF
--- a/servers/src/grin/seed.rs
+++ b/servers/src/grin/seed.rs
@@ -39,6 +39,7 @@ const MAINNET_DNS_SEEDS: &'static [&'static str] = &[
 	"mainnet.seed.grin.lesceller.com", // q.lesceller@gmail.com
 	"mainnet.seed.grin.prokapi.com",   // hendi@prokapi.com
 	"grinseed.yeastplume.org",         // yeastplume@protonmail.com
+	"mainnet-seed.grinnode.live",      // info@grinnode.live
 ];
 const FLOONET_DNS_SEEDS: &'static [&'static str] = &[
 	"floonet.seed.grin.icu",           // gary.peverell@protonmail.com


### PR DESCRIPTION
added mainnet-seed.grinnode.live

Due to the lack of DNS resolution in grin-server.toml for ```seeds =``` I am offering my seed-node to be added. 

By using [DNS Round-Robin](https://en.wikipedia.org/wiki/Round-robin_DNS) (3 nodes) on mainnet-seed.grinnode.live we can provide a high-available seed-node. 

And please fix DNS resolution on **all** possible IP fields in ```grin-server.toml``` (will open separate issues for it) 

---
name: Pull Request
about: Pull Request checklist
title: ''
labels: ''
assignees: ''

---
If your PR is a work in progress, please feel free to create it and include a [WIP] tag in the PR name. We encourage everyone to PR early and often so that other developers know what you're working on.

Before submitting your PR for final review, please ensure that it:

* Includes a proper description of what problems the PR addresses, as well as a detailed explanation as to what it changes
* Explains whether/how the change is consensus breaking or breaks existing client functionality
* Contains unit tests exercising new/changed functionality
* Fully considers the potential impact of the change on other parts of the system
* Describes how you've tested the change (e.g. against Floonet, etc)
* Updates any documentation that's affected by the PR
